### PR TITLE
feat(auth): add email and password registration form

### DIFF
--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -40,13 +40,56 @@ $register = function () {
 
 ?>
 
-<div class="text-center">
-    <p class="pt-2 text-xl font-bold">{{__('Welcome to Pdfpintar')}}</p>
-    <p class="pt-2 pb-6">{{__('Register now it\'s free.')}}</p>
+<div class="dark:bg-neutral-700">
+    <div class="pb-6 pt-2 text-xl font-bold dark:text-neutral-300 text-neutral-900 text-center">
+        <p>{{__('Register now it\'s free.')}}</p>
+    </div>
     
-    <x-button-google-login onclick="loginWithGoogle()" class="justify-center">
+    <x-button-google-login onclick="loginWithGoogle()" class="justify-center w-full">
         {{__('Register with Google')}}
     </x-button-google-login>
+
+    <div class="text-center my-4 text-sm tracking-tight">{{__('Or register with your email and password')}}</div>
+
+    <form wire:submit="register" class="space-y-6">
+        <!-- Name -->
+        <div>
+            <x-input-label for="name" :value="__('Name')" />
+            <x-text-input wire:model="name" id="name" class="block mt-1 w-full" type="text" name="name" required autofocus autocomplete="name" />
+            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+        </div>
+
+        <!-- Email Address -->
+        <div class="mt-4">
+            <x-input-label for="email" :value="__('Email')" />
+            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autocomplete="username" />
+            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+        </div>
+
+        <!-- Password -->
+        <div class="mt-4">
+            <x-input-label for="password" :value="__('Password')" />
+            <x-text-input wire:model="password" id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
+            <x-input-error :messages="$errors->get('password')" class="mt-2" />
+        </div>
+
+        <!-- Confirm Password -->
+        <div class="mt-4">
+            <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
+            <x-text-input wire:model="password_confirmation" id="password_confirmation" class="block mt-1 w-full" type="password" name="password_confirmation" required autocomplete="new-password" />
+            <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
+        </div>
+
+        <div class="flex items-center justify-end mt-4">
+            <a class="underline text-sm text-neutral-600 hover:text-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 dark:text-neutral-400 dark:hover:text-neutral-300" href="{{ route('login') }}" wire:navigate>
+                {{ __('Already registered?') }}
+            </a>
+
+            <x-primary-button class="ms-4">
+                {{ __('Register') }}
+            </x-primary-button>
+        </div>
+    </form>
 
     <form id="social-login-form" action="/login/google/callback" method="POST" style="display: none;">
         {{ csrf_field() }}


### PR DESCRIPTION
Added email, password and name fields to the registration form. Traditional registration flows are fully supported and validated.

<!-- cloder:screenshots -->
## Preview

| Registration Page Screenshot |
| ---------------------------- |
| <img src="https://github.com/ahmadrosid/pdfpintar/releases/download/cloder-screenshots/422eac2c9376.png" alt="Registration Page Screenshot" /> |
<!-- /cloder:screenshots -->